### PR TITLE
Add l10n support and Polish (pl-PL) translation

### DIFF
--- a/Appraisit/Appraisit.csproj
+++ b/Appraisit/Appraisit.csproj
@@ -136,7 +136,9 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <PRIResource Include="Strings\en-us\Resources.resw" />
+    <PRIResource Include="Strings\en-us\Resources.resw">
+      <SubType>Designer</SubType>
+    </PRIResource>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Activation\ActivationHandler.cs" />
@@ -276,6 +278,9 @@
     <Content Include="Assets\Square44x44Logo.scale-200.png" />
     <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
+    <PRIResource Include="Strings\pl\Resources.resw">
+      <SubType>Designer</SubType>
+    </PRIResource>
   </ItemGroup>
   <ItemGroup>
     <None Include=".editorconfig" />

--- a/Appraisit/Helpers/ControversialPostsClass.cs
+++ b/Appraisit/Helpers/ControversialPostsClass.cs
@@ -40,8 +40,8 @@ namespace Appraisit.Helpers
                         {
                             TitleText = post.Title,
                             PostSelf = post,
-                            PostAuthor = "by: " + post.Author,
-                            PostDate = "Created: " + post.Created,
+                            PostAuthor = string.Format("PostBy".GetLocalized(), post.Author),
+                            PostDate = string.Format("PostDate".GetLocalized(), post.Created),
                             PostUpvotes = post.UpVotes.ToString(),
                             PostDownvotes = post.DownVotes.ToString(),
                             PostCommentCount = post.Comments.GetComments("new").Count.ToString(),

--- a/Appraisit/Helpers/HotPostsClass.cs
+++ b/Appraisit/Helpers/HotPostsClass.cs
@@ -41,8 +41,8 @@ namespace Appraisit.Helpers
                         {
                             TitleText = post.Title,
                             PostSelf = post,
-                            PostAuthor = "by: " + post.Author,
-                            PostDate = "Created: " + post.Created,
+                            PostAuthor = string.Format("PostBy".GetLocalized(), post.Author),
+                            PostDate = string.Format("PostDate".GetLocalized(), post.Created),
                             PostUpvotes = post.UpVotes.ToString(),
                             PostDownvotes = post.DownVotes.ToString(),
                             PostCommentCount = post.Comments.GetComments("new").Count.ToString(),

--- a/Appraisit/Helpers/NewPostsClass.cs
+++ b/Appraisit/Helpers/NewPostsClass.cs
@@ -58,8 +58,8 @@ namespace Appraisit.Helpers
                   {
                       TitleText = post.Title,
                       PostSelf = post,
-                      PostAuthor = "by: " + post.Author,
-                      PostDate = "Created: " + post.Created,
+                      PostAuthor = string.Format("PostBy".GetLocalized(), post.Author),
+                      PostDate = string.Format("PostDate".GetLocalized(), post.Created),
                       PostUpvotes = post.UpVotes.ToString(),
                       PostDownvotes = post.DownVotes.ToString(),
                       PostCommentCount = (post.Comments.GetComments("new").Count.ToString()),

--- a/Appraisit/Helpers/RisingPostClass.cs
+++ b/Appraisit/Helpers/RisingPostClass.cs
@@ -41,8 +41,8 @@ namespace Appraisit.Helpers
                         {
                             TitleText = post.Title,
                             PostSelf = post,
-                            PostAuthor = "by: " + post.Author,
-                            PostDate = "Created: " + post.Created,
+                            PostAuthor = string.Format("PostBy".GetLocalized(), post.Author),
+                            PostDate = string.Format("PostDate".GetLocalized(), post.Created),
                             PostUpvotes = post.UpVotes.ToString(),
                             PostDownvotes = post.DownVotes.ToString(),
                             PostCommentCount = post.Comments.GetComments("new").Count.ToString(),

--- a/Appraisit/Helpers/TopPostsClass.cs
+++ b/Appraisit/Helpers/TopPostsClass.cs
@@ -11,10 +11,19 @@ using System.Threading.Tasks;
 
 namespace Appraisit.Helpers
 {
+    public enum TopOrder
+    {
+        All,
+        Year,
+        Month,
+        Week,
+        Day
+    }
+
     public class TopPostsClass : IIncrementalSource<Posts>
     {
         public Windows.Storage.ApplicationDataContainer localSettings = Windows.Storage.ApplicationData.Current.LocalSettings;
-        public string Order = "all";
+        public TopOrder Order = TopOrder.All;
         public string secret = "SESshAirmwAuAvBFHbq_JUkAMmk";
         public string appId = "-bL9o_t7kgNNmA";
         List<Posts> PostCollection;
@@ -28,7 +37,7 @@ namespace Appraisit.Helpers
                 PostCollection = new List<Posts>();
                 var reddit = new RedditAPI(appId, refreshToken, secret);
                 var subreddit = reddit.Subreddit("Appraisit");
-                var posts = subreddit.Posts.GetTop(new TimedCatSrListingInput(t: "all", limit: limit)).Skip(skipInt);
+                var posts = subreddit.Posts.GetTop(new TimedCatSrListingInput(t: TopOrderToString(Order), limit: limit)).Skip(skipInt);
                 limit = limit + 10;
                 
                     foreach (Post post in posts)
@@ -42,8 +51,8 @@ namespace Appraisit.Helpers
                         {
                             TitleText = post.Title,
                             PostSelf = post,
-                            PostAuthor = "by: " + post.Author,
-                            PostDate = "Created: " + post.Created,
+                            PostAuthor = string.Format("PostBy".GetLocalized(), post.Author),
+                            PostDate = string.Format("PostDate".GetLocalized(), post.Created),
                             PostUpvotes = post.UpVotes.ToString(),
                             PostDownvotes = post.DownVotes.ToString(),
                             PostCommentCount = post.Comments.GetComments("new").Count.ToString(),
@@ -61,6 +70,19 @@ namespace Appraisit.Helpers
             return PostCollection;
 
 
+        }
+
+        private string TopOrderToString(TopOrder to)
+        {
+            switch (to)
+            {
+                case TopOrder.All: return "all";
+                case TopOrder.Day: return "day";
+                case TopOrder.Month: return "month";
+                case TopOrder.Week: return "week";
+                case TopOrder.Year: return "year";
+                default: return "all";
+            }
         }
     }
 }

--- a/Appraisit/Strings/pl/Resources.resw
+++ b/Appraisit/Strings/pl/Resources.resw
@@ -126,11 +126,11 @@
     <comment>Application description</comment>
   </data>
   <data name="Main_Title.Text" xml:space="preserve">
-    <value>Main</value>
+    <value>Strona główna</value>
     <comment>Page title for MainPage</comment>
   </data>
   <data name="FirstRun_Body.Text" xml:space="preserve">
-    <value>Replace the content of this dialog with whatever content is appropriate to your app.
+    <value>ąReplace the content of this dialog with whatever content is appropriate to your app.
 You might want to explain key features or functionality.
 Don't feel restricted to just text. You can also include images and animations if you wish too.
 
@@ -144,15 +144,15 @@ Suspendisse dui purus, scelerisque at, vulputate vitae, pretium mattis, nunc. Ma
     <comment>First use prompt message body</comment>
   </data>
   <data name="FirstRunDialog.Title" xml:space="preserve">
-    <value>Welcome</value>
+    <value>Witaj</value>
     <comment>First use prompt message title</comment>
   </data>
   <data name="FirstRunDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Login</value>
+    <value>Zaloguj się</value>
     <comment>First use prompt message primary button text</comment>
   </data>
   <data name="WhatsNewDialog.Title" xml:space="preserve">
-    <value>What's new in this version</value>
+    <value>Co nowego w tej wersji</value>
     <comment>What's new prompt message title</comment>
   </data>
   <data name="WhatsNewDialog.PrimaryButtonText" xml:space="preserve">
@@ -160,152 +160,152 @@ Suspendisse dui purus, scelerisque at, vulputate vitae, pretium mattis, nunc. Ma
     <comment>What's new prompt message primary button text</comment>
   </data>
   <data name="AlreadyPinnedDesc" xml:space="preserve">
-    <value>If not you can manually pin the app to the taskbar</value>
+    <value>Jeśli nie, możesz przypiąć ją ręcznie</value>
   </data>
   <data name="AlreadyPinnedTitle" xml:space="preserve">
-    <value>You already have the app pinned in your taskbar</value>
+    <value>Już przypiąłeś Appraisin do paska zadań</value>
   </data>
   <data name="AlreadyTile" xml:space="preserve">
-    <value>You already have the live tile in your StartScreen</value>
+    <value>Już przypiąłeś kafelek do menu Start</value>
   </data>
   <data name="AlreadyTileDesc" xml:space="preserve">
-    <value>If not you can manually put the live tile on to the StartScreen</value>
+    <value>Jeśli nie, możesz przypiąć go ręcznie</value>
   </data>
   <data name="CantCommentWithoutSignin" xml:space="preserve">
-    <value>Cant comment without sign in</value>
+    <value>Nie możesz komentować bez zalogowania się</value>
   </data>
   <data name="CantDownvoteWithoutSignin" xml:space="preserve">
-    <value>Cant downvote without sign in</value>
+    <value>Nie możesz dawać głosów w dół bez zalogowania się</value>
   </data>
   <data name="CantReplyWithoutSignin" xml:space="preserve">
-    <value>Cant reply without sign in</value>
+    <value>Nie możesz odpowiadać bez zalogowania się</value>
   </data>
   <data name="CantUpvoteWithoutSignin" xml:space="preserve">
-    <value>Cant upvote without sign in</value>
+    <value>Nie możesz dawać głosów w górę bez zalogowania się</value>
   </data>
   <data name="CommentSent" xml:space="preserve">
-    <value>Comment sent (refresh to view)</value>
+    <value>Komentarz wysłany (odśwież aby go zobaczyć)</value>
   </data>
   <data name="Downvoted" xml:space="preserve">
-    <value>Downvoted</value>
+    <value>Zagłosowano w dół</value>
   </data>
   <data name="FirstText.Text" xml:space="preserve">
-    <value>Login to reddit
-appraisit is powered by reddit</value>
+    <value>Zaloguj się do reddita
+appraisit jest napędzany przez reddita</value>
   </data>
   <data name="FirstTextOnMobile" xml:space="preserve">
-    <value>The app hasnt been tested on mobile; report bugs, crashes, requests in the feedback hub. Mobile beta</value>
+    <value>Ta aplikacja nie była testowana na telefonie; zgłaszaj błędy, crashe i pomysły.</value>
   </data>
   <data name="Flair" xml:space="preserve">
-    <value>Flair: {0}</value>
+    <value>Znaczek: {0}</value>
   </data>
   <data name="GPODisabledPin" xml:space="preserve">
-    <value>It seems you are using a computer. Group policy disabled pinning of app in taskbar</value>
+    <value>Wygląda na to że używasz komputera, na którym polisy grupowe zablokowały przypinanie aplikacji do paska zadań</value>
   </data>
   <data name="HololensDisabledPin" xml:space="preserve">
-    <value>It seems you are using hololens. Hololens doesn't have a taskbar</value>
+    <value>Wygląda na to, że używasz HoloLens. HoloLens nie ma paska zadań.</value>
   </data>
   <data name="HololensTileFail" xml:space="preserve">
-    <value>It seems you are using hololens. Hololens doesn't support live tile</value>
+    <value>Wygląda na to, że używasz HoloLens. HoloLens nie obsługuje żywych kafelków.</value>
   </data>
   <data name="IoTDisabledPin" xml:space="preserve">
-    <value>It seems you are using a IoT device which doesn't support taskbar pin API</value>
+    <value>Wygląda na to, że używasz urządzenia IoT, które nie obsługuje przypinania do paska zadań.</value>
   </data>
   <data name="IoTTileFail" xml:space="preserve">
-    <value>It seems you are using a IoT device which doesn't support Primary tile API</value>
+    <value>Wygląda na to, że używasz urządzenia IoT, które nie obsługuje żywych kafelków.</value>
   </data>
   <data name="LiveTileFailed" xml:space="preserve">
-    <value>live tile failed</value>
+    <value>Nie udało się przypiąć kafelka</value>
   </data>
   <data name="MyCommentKarma" xml:space="preserve">
-    <value>Comment Karma: {0}</value>
+    <value>Karma komentarzy: {0}</value>
   </data>
   <data name="MyCreated" xml:space="preserve">
-    <value>Created/Cake Day: {0}</value>
+    <value>Utworzono: {0}</value>
   </data>
   <data name="MyKarma" xml:space="preserve">
     <value>Karma: {0}</value>
   </data>
   <data name="MyUsername" xml:space="preserve">
-    <value>Username: {0}</value>
+    <value>Nazwa użytkownika: {0}</value>
   </data>
   <data name="NoInternetConnection" xml:space="preserve">
-    <value>No internet connection</value>
+    <value>Brak dostępu do internetu</value>
   </data>
   <data name="OtherDisabledPin" xml:space="preserve">
-    <value>It seems you are using a {0} device. This device does not support taskbar API or Group policy disabled pinning of the app</value>
+    <value>Wygląda na to, że używasz urządzenia typu {0}, które nie obsługuje przypinania do paska zadań lub zostało to wyłączone.</value>
   </data>
   <data name="OtherTileFail" xml:space="preserve">
-    <value>It seems you are using a {0} device. This device does not support Primary tile API</value>
+    <value>Wygląda na to, że używasz urządzenia typu {0}, które nie obsługuje przypinania kafelków.</value>
   </data>
   <data name="PostBy" xml:space="preserve">
-    <value>by: {0}</value>
+    <value>przez: {0}</value>
   </data>
   <data name="PostCreated" xml:space="preserve">
-    <value>Post created (refresh to view)</value>
+    <value>Post dodany (odśwież, aby go zobaczyć)</value>
   </data>
   <data name="PostDate" xml:space="preserve">
-    <value>Created: {0}</value>
+    <value>Utworzono: {0}</value>
   </data>
   <data name="ReplySent" xml:space="preserve">
-    <value>Reply sent (viewing replies isnt supported, go to appraisit subreddit on web to view)</value>
+    <value>Odpowiedź wysłana</value>
   </data>
   <data name="SignInTip" xml:space="preserve">
-    <value>Sign in to access more features such as light mode, search, create post, commenting and settings.</value>
+    <value>Zaloguj się, aby uzyskać dostęp do większej liczby funkcji takich jak tryb jasny, szukanie, dodawanie postów, komentowanie i ustawienia.</value>
   </data>
   <data name="TaskbarPinFailed" xml:space="preserve">
-    <value>Taskbar pin failed</value>
+    <value>Przypinanie się nie powiodło</value>
   </data>
   <data name="UpdateDevice" xml:space="preserve">
-    <value>Update your device</value>
+    <value>Zaktualizuj swoje urządzenie</value>
   </data>
   <data name="UpdateToPin" xml:space="preserve">
-    <value>Update your device to the Fall creators update or higher to pin this app</value>
+    <value>Musisz zaktualizować swoje urządzenie co najmniej do Jesiennej Aktualizacji dla Twórców, aby móc przypiąć tę aplikację.</value>
   </data>
   <data name="UpdateToTile" xml:space="preserve">
-    <value>You need to update your device to enable automatic pinning</value>
+    <value>Musisz zaktualizować swoje urządzenie, aby skorzystać z tej funkcji.</value>
   </data>
   <data name="Upvoted" xml:space="preserve">
-    <value>Upvoted</value>
+    <value>Zagłosowano w górę</value>
   </data>
   <data name="WoAGPODisabledPin" xml:space="preserve">
-    <value>It seems you are using a Windows 10 on ARM device or mobile device. Group policy disabled pinning of the app</value>
+    <value>Wygląda na to, że używasz Windows 10 na urządzeniu ARM lub na telefonie. Polisy grupy zablokowały przypinanie do ekranu startowego.</value>
   </data>
   <data name="XboxDisabledPin" xml:space="preserve">
-    <value>It seems you are using a xbox. Xbox doesn't have a taskbar</value>
+    <value>Wygląda na to, że używasz Xboksa. Xbox nie posiada paska zadań.</value>
   </data>
   <data name="XboxTileFail" xml:space="preserve">
-    <value>It seems you are using a xbox. Xbox doesn't support live tile</value>
+    <value>Wygląda na to, że używasz Xboksa. Xbox nie posiada obsługi żywych kafelków.</value>
   </data>
   <data name="AboutPI.Header" xml:space="preserve">
-    <value>About</value>
+    <value>O programie</value>
   </data>
   <data name="BestPi.Header" xml:space="preserve">
-    <value>Best</value>
+    <value>Najlepsze</value>
   </data>
   <data name="CommentTextMessage.Header" xml:space="preserve">
-    <value>Comment:</value>
+    <value>Komentarz:</value>
   </data>
   <data name="CommentTextMessage.PlaceholderText" xml:space="preserve">
-    <value>this is a comment</value>
+    <value>to jest komentarz</value>
   </data>
   <data name="ControversialPi.Header" xml:space="preserve">
-    <value>Controversial</value>
+    <value>Kontrowersyjne</value>
   </data>
   <data name="CreatePostDialog.CloseButtonText" xml:space="preserve">
-    <value>Close</value>
+    <value>Zamknij</value>
   </data>
   <data name="CreatePostSwipe.Text" xml:space="preserve">
-    <value>Create post</value>
+    <value>Stwórz post</value>
   </data>
   <data name="CreatePsotDialog.PrimaryButtonText" xml:space="preserve">
-    <value>Post</value>
+    <value>Wyślij</value>
   </data>
   <data name="DownvoteMFI.Text" xml:space="preserve">
-    <value>Downvote</value>
+    <value>Zagłosuj w dół</value>
   </data>
   <data name="FlairLabel.Text" xml:space="preserve">
-    <value>Flair:</value>
+    <value>Znaczek:</value>
   </data>
   <data name="LinkNavigator.Label" xml:space="preserve">
     <value>Link</value>
@@ -317,195 +317,195 @@ appraisit is powered by reddit</value>
     <value>Link</value>
   </data>
   <data name="LivePi.Header" xml:space="preserve">
-    <value>Live</value>
+    <value>Link</value>
   </data>
   <data name="LivePin.Content" xml:space="preserve">
-    <value>Pin to startscreen</value>
+    <value>Przypnij do menu Start</value>
   </data>
   <data name="NewPi.Header" xml:space="preserve">
-    <value>New</value>
+    <value>Nowe</value>
   </data>
   <data name="NewPostLink.Header" xml:space="preserve">
     <value>Link:</value>
   </data>
   <data name="NewPostLink.PlaceholderText" xml:space="preserve">
-    <value>Must be a valid link</value>
+    <value>Musi to być poprawny link</value>
   </data>
   <data name="OldPi.Header" xml:space="preserve">
-    <value>Old</value>
+    <value>Stare</value>
   </data>
   <data name="OpenCreatePostDialog.Label" xml:space="preserve">
-    <value>Create post</value>
+    <value>Stwórz post</value>
   </data>
   <data name="Openinweb.Label" xml:space="preserve">
-    <value>Web</value>
+    <value>Przeglądaj</value>
   </data>
   <data name="OpenInWebMFI.Text" xml:space="preserve">
-    <value>Open in web</value>
+    <value>Otwórz w przeglądarce</value>
   </data>
   <data name="OpenSearchDialog.Label" xml:space="preserve">
-    <value>Search</value>
+    <value>Szukaj</value>
   </data>
   <data name="PinAppToTaskbar.Content" xml:space="preserve">
-    <value>Pin to taskbar</value>
+    <value>Przypnij do paska zadań</value>
   </data>
   <data name="PostDialog.CloseButtonText" xml:space="preserve">
-    <value>Close</value>
+    <value>Zamknij</value>
   </data>
   <data name="PostText.Header" xml:space="preserve">
-    <value>Text:</value>
+    <value>Tekst</value>
   </data>
   <data name="PostText.PlaceholderText" xml:space="preserve">
-    <value>Remember to put version number, links are optional</value>
+    <value>Pamiętaj aby podać numer wersji, linki są opcjonalne</value>
   </data>
   <data name="PrivacyHB.Content" xml:space="preserve">
-    <value>Privacy Statement</value>
+    <value>Polityka prywatności</value>
   </data>
   <data name="ProfileButton.Label" xml:space="preserve">
-    <value>Profile</value>
+    <value>Profil</value>
   </data>
   <data name="QandAPi.Header" xml:space="preserve">
-    <value>Q and A</value>
+    <value>Q&amp;A</value>
   </data>
   <data name="Rate.Content" xml:space="preserve">
-    <value>Rate Appraisit</value>
+    <value>Oceń Appraisit</value>
   </data>
   <data name="RedditPi.Header" xml:space="preserve">
     <value>Reddit</value>
   </data>
   <data name="Refresh.Label" xml:space="preserve">
-    <value>Refresh</value>
+    <value>Odśwież</value>
   </data>
   <data name="RefreshCommentsABB.Label" xml:space="preserve">
-    <value>Refresh comments</value>
+    <value>Odśwież komentarze</value>
   </data>
   <data name="RefreshCommentsMFI.Text" xml:space="preserve">
-    <value>Refresh comments</value>
+    <value>Odśwież komentarze</value>
   </data>
   <data name="RefreshSwipe.Text" xml:space="preserve">
-    <value>Refresh</value>
+    <value>Odśwież</value>
   </data>
   <data name="RepliesPi.Header" xml:space="preserve">
-    <value>Replies (experimental)</value>
+    <value>Odpowiedzi (eksperymentalne)</value>
   </data>
   <data name="ReplyExpander.Header" xml:space="preserve">
-    <value>Reply</value>
+    <value>Odpowiedz</value>
   </data>
   <data name="ReplyText.Header" xml:space="preserve">
-    <value>Reply:</value>
+    <value>Odpowiedź:</value>
   </data>
   <data name="ReplyText.PlaceholderText" xml:space="preserve">
-    <value>Send a reply</value>
+    <value>Wyślij odpowiedź</value>
   </data>
   <data name="SB.Label" xml:space="preserve">
-    <value>Settings</value>
+    <value>Ustawienia</value>
   </data>
   <data name="SearchAppraisitABB.Label" xml:space="preserve">
-    <value>Search appraisit</value>
+    <value>Przeszukaj appraisit</value>
   </data>
   <data name="SearchAppraisitMFI.Text" xml:space="preserve">
-    <value>Search appraisit</value>
+    <value>Przeszukaj appraisit</value>
   </data>
   <data name="SearchBox.PlaceholderText" xml:space="preserve">
-    <value>Search posts:</value>
+    <value>Szukaj postów:</value>
   </data>
   <data name="SearchPostsSwipe.Text" xml:space="preserve">
-    <value>Search posts</value>
+    <value>Szukaj postów</value>
   </data>
   <data name="SearchRedditABB.Label" xml:space="preserve">
-    <value>Search on reddit</value>
+    <value>Szukaj na reddicie</value>
   </data>
   <data name="SearchRedditMFI.Text" xml:space="preserve">
-    <value>Search on reddit</value>
+    <value>Szukaj na reddicie</value>
   </data>
   <data name="SearchStoreABB.Label" xml:space="preserve">
-    <value>Search on store</value>
+    <value>Szukaj w sklepie</value>
   </data>
   <data name="SearchStoreMFI.Text" xml:space="preserve">
-    <value>Search on store</value>
+    <value>Szukaj w sklepie</value>
   </data>
   <data name="SearchTip.Title" xml:space="preserve">
-    <value>Search</value>
+    <value>Szukaj</value>
   </data>
   <data name="SettingOpenButton.Label" xml:space="preserve">
-    <value>Settings</value>
+    <value>Ustawienia</value>
   </data>
   <data name="Settings_Theme_Dark.Content" xml:space="preserve">
-    <value>Dark</value>
+    <value>Ciemny</value>
   </data>
   <data name="Settings_Theme_Default.Content" xml:space="preserve">
-    <value>Default</value>
+    <value>Domyślny</value>
   </data>
   <data name="Settings_Theme_Light.Content" xml:space="preserve">
-    <value>Light</value>
+    <value>Jasny</value>
   </data>
   <data name="SignIn.Content" xml:space="preserve">
-    <value>Sign in</value>
+    <value>Zaloguj się</value>
   </data>
   <data name="SignInABB.Label" xml:space="preserve">
-    <value>Sign in</value>
+    <value>Zaloguj się</value>
   </data>
   <data name="SignOutButton.Content" xml:space="preserve">
-    <value>Sign out</value>
+    <value>Wyloguj się</value>
   </data>
   <data name="StorePi.Header" xml:space="preserve">
-    <value>Store</value>
+    <value>Sklep</value>
   </data>
   <data name="TextPi.Header" xml:space="preserve">
-    <value>Text</value>
+    <value>Tekst</value>
   </data>
   <data name="TitlePost.Header" xml:space="preserve">
-    <value>Title:</value>
+    <value>Tytuł</value>
   </data>
   <data name="TitlePostText.PlaceholderText" xml:space="preserve">
-    <value>Appraisit updated to version 3.0</value>
+    <value>np. Appraisit zaktualizowany do wersji 3.0</value>
   </data>
   <data name="TopOrder.PlaceholderText" xml:space="preserve">
-    <value>all</value>
+    <value>z zawsze</value>
   </data>
   <data name="TopPi.Header" xml:space="preserve">
-    <value>Top</value>
+    <value>Najwyżej punktowane</value>
   </data>
   <data name="UpvoteMFI.Text" xml:space="preserve">
-    <value>Upvote</value>
+    <value>Zagłosuj w górę</value>
   </data>
   <data name="WebBarButton.Label" xml:space="preserve">
-    <value>Web</value>
+    <value>Przeglądaj</value>
   </data>
   <data name="WebPi.Header" xml:space="preserve">
-    <value>Web</value>
+    <value>Przeglądaj</value>
   </data>
   <data name="Whatsnew.Content" xml:space="preserve">
-    <value>What's new</value>
+    <value>Co nowego</value>
   </data>
   <data name="WhatsNewPI.Header" xml:space="preserve">
-    <value>What's new</value>
+    <value>Co nowego</value>
   </data>
   <data name="ControversialTVI.Header" xml:space="preserve">
-    <value>Controversial</value>
+    <value>Kontrowersyjne</value>
   </data>
   <data name="ExplorePi.Header" xml:space="preserve">
-    <value>Explore</value>
+    <value>Eksploruj</value>
   </data>
   <data name="HotPi.Header" xml:space="preserve">
-    <value>Hot</value>
+    <value>Gorące</value>
   </data>
   <data name="RisingTVI.Header" xml:space="preserve">
-    <value>Rising</value>
+    <value>Rosnące</value>
   </data>
   <data name="SearchMFI.Text" xml:space="preserve">
-    <value>Search</value>
+    <value>Szukaj</value>
   </data>
   <data name="SettingsPi.Header" xml:space="preserve">
-    <value>Settings</value>
+    <value>Ustawienia</value>
   </data>
   <data name="TopOrderItems" xml:space="preserve">
-    <value>all|year|month|week|day</value>
+    <value>z zawsze|z ostatniego roku|z ostatniego miesiąca|z ostatniego tygodnia|dzisiaj</value>
   </data>
   <data name="SearchMicrosoftStoreButton.Content" xml:space="preserve">
-    <value>Search Microsoft Store</value>
+    <value>Szukaj w Sklepie Microsoft</value>
   </data>
   <data name="SearchRedditWebButton.Content" xml:space="preserve">
-    <value>Search reddit on web</value>
+    <value>Szukaj na reddicie</value>
   </data>
 </root>

--- a/Appraisit/Views/FirstRunDialog.xaml
+++ b/Appraisit/Views/FirstRunDialog.xaml
@@ -22,7 +22,8 @@
             <TextBlock
                 x:Name="FirstText"
                 IsTextSelectionEnabled="True"
-                TextWrapping="WrapWholeWords">
+                TextWrapping="WrapWholeWords"
+                x:Uid="FirstText">
                Login to reddit
                 <LineBreak/>
                 appraisit is powered by reddit

--- a/Appraisit/Views/FirstRunDialog.xaml.cs
+++ b/Appraisit/Views/FirstRunDialog.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Appraisit.Helpers;
+using System;
 using Windows.System.Profile;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -14,7 +15,7 @@ namespace Appraisit.Views
             InitializeComponent();
             if (AnalyticsInfo.VersionInfo.DeviceFamily == "Windows.Mobile")
             {
-                FirstText.Text = "The app hasnt been tested on mobile; report bugs, crashes, requests in the feedback hub. Mobile beta";
+                FirstText.Text = "FirstTextOnMobile".GetLocalized();
             }
         }
     }

--- a/Appraisit/Views/MainPage.xaml
+++ b/Appraisit/Views/MainPage.xaml
@@ -107,17 +107,17 @@
                 <muxcontrols:SwipeControl HorizontalAlignment="Center" VerticalAlignment="Center">
                     <muxcontrols:SwipeControl.RightItems>
                         <muxcontrols:SwipeItems>
-                            <muxcontrols:SwipeItem Text="Create post" Background="Red" Invoked="SwipeItem_Invoked_1">
+                            <muxcontrols:SwipeItem x:Uid="CreatePostSwipe" Text="Create post" Background="Red" Invoked="SwipeItem_Invoked_1">
                                 <muxcontrols:SwipeItem.IconSource>
                                     <muxcontrols:SymbolIconSource Symbol="Add"/>
                                 </muxcontrols:SwipeItem.IconSource>
                             </muxcontrols:SwipeItem>
-                            <muxcontrols:SwipeItem Text="Search posts" Background="Green" Invoked="SwipeItem_Invoked_2">
+                            <muxcontrols:SwipeItem x:Uid="SearchPostsSwipe" Text="Search posts" Background="Green" Invoked="SwipeItem_Invoked_2">
                                 <muxcontrols:SwipeItem.IconSource>
                                     <muxcontrols:SymbolIconSource Symbol="Find"/>
                                 </muxcontrols:SwipeItem.IconSource>
                             </muxcontrols:SwipeItem>
-                            <muxcontrols:SwipeItem Text="Refresh" Background="Blue" Invoked="SwipeItem_Invoked_3">
+                            <muxcontrols:SwipeItem x:Uid="RefreshSwipe" Text="Refresh" Background="Blue" Invoked="SwipeItem_Invoked_3">
                                 <muxcontrols:SwipeItem.IconSource>
                                     <muxcontrols:SymbolIconSource Symbol="Refresh"/>
                                 </muxcontrols:SwipeItem.IconSource>
@@ -173,18 +173,18 @@
                             </StackPanel>
                             <FlyoutBase.AttachedFlyout>
                                 <MenuFlyout>
-                                    <MenuFlyoutItem Text="Open in web" Icon="Globe" Click="PostInWebClickLocal"/>
+                                    <MenuFlyoutItem x:Uid="OpenInWebMFI" Text="Open in web" Icon="Globe" Click="PostInWebClickLocal"/>
                                     <MenuFlyoutSeparator/>
-                                    <MenuFlyoutItem Text="Upvote" Icon="Like" Click="Upvotes_Click"/>
-                                    <MenuFlyoutItem Text="Downvote" Icon="Dislike" Click="Downvotes_Click"/>
+                                    <MenuFlyoutItem x:Uid="UpvoteMFI" Text="Upvote" Icon="Like" Click="Upvotes_Click"/>
+                                    <MenuFlyoutItem x:Uid="DownvoteMFI" Text="Downvote" Icon="Dislike" Click="Downvotes_Click"/>
                                     <MenuFlyoutSeparator/>
-                                    <MenuFlyoutSubItem Text="Search">
-                                        <MenuFlyoutItem Text="Search appraisit" Icon="Find" Click="MenuFlyoutItem_Click_1"/>
-                                        <MenuFlyoutItem Text="Search on reddit" Icon="Find" Click="MenuFlyoutItem_Click_2"/>
-                                        <MenuFlyoutItem Text="Search on store" Icon="Find" Click="MenuFlyoutItem_Click"/>
+                                    <MenuFlyoutSubItem Text="Search" x:Uid="SearchMFI">
+                                        <MenuFlyoutItem x:Uid="SearchAppraisitMFI" Text="Search appraisit" Icon="Find" Click="MenuFlyoutItem_Click_1"/>
+                                        <MenuFlyoutItem x:Uid="SearchRedditMFI" Text="Search on reddit" Icon="Find" Click="MenuFlyoutItem_Click_2"/>
+                                        <MenuFlyoutItem x:Uid="SearchStoreMFI" Text="Search on store" Icon="Find" Click="MenuFlyoutItem_Click"/>
                                     </MenuFlyoutSubItem>
                                     <MenuFlyoutSeparator/>
-                                    <MenuFlyoutItem Text="Refresh comments" Icon="Refresh" Click="MenuFlyoutItem_Click_3"/>
+                                    <MenuFlyoutItem x:Uid="RefreshCommentsMFI" Text="Refresh comments" Icon="Refresh" Click="MenuFlyoutItem_Click_3"/>
                                 </MenuFlyout>
                             </FlyoutBase.AttachedFlyout>
                         </StackPanel>
@@ -295,9 +295,9 @@
                             <AppBarButton x:Name="Upvotes" Icon="Like"  Label="{Binding CommentUpvotes}" Background='{ThemeResource SystemControlChromeMediumAcrylicElementMediumBrush}' Click="Upvotes_Click"></AppBarButton>
                             <AppBarButton x:Name="Downvotes" Icon="Dislike" Label="{Binding CommentDownvotes}" Background='{ThemeResource SystemControlChromeMediumAcrylicElementMediumBrush}' Click="Downvotes_Click"></AppBarButton>
                         </CommandBar>
-                        <controls:Expander Header="Reply" IsExpanded="false">
+                        <controls:Expander Header="Reply" IsExpanded="false" x:Uid="ReplyExpander">
                             <StackPanel Orientation="Vertical" Margin="10">
-                                <AutoSuggestBox Header="Reply:" PlaceholderText="Send a reply" x:Name="ReplyText" QueryIcon="Comment" QuerySubmitted="ReplyText_QuerySubmitted" Width="300"></AutoSuggestBox>
+                                <AutoSuggestBox x:Uid="ReplyText" Header="Reply:" PlaceholderText="Send a reply" x:Name="ReplyText" QueryIcon="Comment" QuerySubmitted="ReplyText_QuerySubmitted" Width="300"></AutoSuggestBox>
                             </StackPanel>
                         </controls:Expander>
                     </StackPanel>
@@ -323,7 +323,7 @@
             <WebView x:Name="loginView" NavigationStarting="LoginView_NavigationStarting" RequestedTheme="Dark" x:Load="False"/>
             <Grid x:Name="ContentGrid" Canvas.ZIndex="0">
                 <Pivot HorizontalAlignment="Center" x:Name="PivotNavigator" SelectionChanged="Pivot_SelectionChanged" Foreground="Purple">
-                    <PivotItem Header="New" x:Name="NewPivotItem">
+                    <PivotItem Header="New" x:Name="NewPivotItem" x:Uid="NewPi">
                         <Grid>
                             
                             <AppBarButton Icon="Switch" Click="UniversalZoomButton_Click" Height="40" Canvas.ZIndex="100">></AppBarButton>
@@ -345,7 +345,7 @@
                             </muxcontrols:RefreshContainer>
                         </Grid>
                     </PivotItem>
-                    <PivotItem Header="Hot">
+                    <PivotItem Header="Hot" x:Uid="HotPi">
                         <Grid>
                             <AppBarButton Icon="Switch" Click="UniversalZoomButton_Click" Height="40" Canvas.ZIndex="100"></AppBarButton>
                             <muxcontrols:RefreshContainer RefreshRequested="RefreshContainer_RefreshRequested" Margin="0, 40, 0, 0">
@@ -365,9 +365,9 @@
                         </Grid>
 
                     </PivotItem>
-                    <PivotItem Header="Top">
+                    <PivotItem Header="Top" x:Uid="TopPi">
                         <Grid>
-                            <ComboBox SelectionChanged="TopComboBox_SelectionChanged" x:Name="TopOrder" Canvas.ZIndex="100" PlaceholderText="all" Width="200">
+                            <ComboBox SelectionChanged="TopComboBox_SelectionChanged" x:Name="TopOrder" x:Uid="TopOrder"  Canvas.ZIndex="100" PlaceholderText="all" Width="200">
                                 <x:String>all</x:String>
                                 <x:String>year</x:String>
                                 <x:String>month</x:String>
@@ -397,7 +397,7 @@
                             </muxcontrols:RefreshContainer>
                         </Grid>
                     </PivotItem>
-                    <PivotItem Header="Explore">
+                    <PivotItem Header="Explore" x:Uid="ExplorePi">
                         <controls:TabView CanCloseTabs="False" x:Name="ExtraNavigationView" x:Load="False">
                           <!--  <controls:TabViewItem Header="Website">
                                 <Grid>
@@ -413,7 +413,7 @@
                                     </CommandBar>
                                 </Grid>
                             </controls:TabViewItem>-->
-                            <controls:TabViewItem Header="Rising">
+                            <controls:TabViewItem Header="Rising" x:Uid="RisingTVI">
                                 <Grid>
                                     <AppBarButton Icon="Switch" Click="UniversalZoomButton_Click" Height="40" Canvas.ZIndex="100"></AppBarButton>
                                     <muxcontrols:RefreshContainer RefreshRequested="RefreshContainer_RefreshRequested" Margin="0, 40, 0, 0">
@@ -437,7 +437,7 @@
                                     </muxcontrols:RefreshContainer>
                                 </Grid>
                             </controls:TabViewItem>
-                            <controls:TabViewItem Header="Controversial">
+                            <controls:TabViewItem Header="Controversial" x:Uid="ControversialTVI">
                                 <Grid>
                                     <AppBarButton Icon="Switch" Click="UniversalZoomButton_Click" Height="40" Canvas.ZIndex="100"></AppBarButton>
                                     <muxcontrols:RefreshContainer RefreshRequested="RefreshContainer_RefreshRequested" Margin="0, 40, 0, 0">
@@ -468,9 +468,9 @@
                         <Grid>
                             <CommandBar Background='{ThemeResource SystemControlAcrylicWindowBrush}' x:Name="PivotBar" OverflowButtonVisibility="Collapsed" DefaultLabelPosition="Right" x:Load="True">
                                 <!--<AppBarButton Icon="AddFriend" x:Name="LoginDialogOpen" Click="LoginDialogOpen_Click"></AppBarButton>-->
-                                <AppBarButton Icon="Setting" Label="Settings" x:Name="SettingOpenButton" Click="SettingOpenButton_Click"/>
-                                <AppBarButton Icon="Globe" Label="Web" Click="WebBarButton_Click"/>
-                                <AppBarButton Icon="AddFriend" Label="Profile" Click="ProfileButton_Click">
+                                <AppBarButton Icon="Setting" x:Uid="SettingOpenButton" Label="Settings" x:Name="SettingOpenButton" Click="SettingOpenButton_Click"/>
+                                <AppBarButton Icon="Globe" Label="Web" x:Uid="WebBarButton" Click="WebBarButton_Click"/>
+                                <AppBarButton Icon="AddFriend" Label="Profile" x:Uid="ProfileButton" Click="ProfileButton_Click">
                                     <AppBarButton.Flyout>
                                         <Flyout>
                                             <StackPanel>
@@ -478,27 +478,27 @@
                                                 <TextBlock x:Name="Cakeday" Margin="0, 0, 0, 12"/>
                                                 <TextBlock x:Name="LinkKarma" Margin="0, 0, 0, 12"/>
                                                 <TextBlock x:Name="CommentKarma" Margin="0, 0, 0, 12"/>
-                                                <Button Click="SignOutButton_Click">Sign out</Button>
+                                                <Button x:Uid="SignOutButton" Click="SignOutButton_Click">Sign out</Button>
                                             </StackPanel>
                                         </Flyout>
                                     </AppBarButton.Flyout>
                                 </AppBarButton>
-                                <AppBarButton Icon="Refresh" Label="Refresh" Click="Refresh"/>
-                                <AppBarButton Icon="Find" Label="Search" Click="OpenSearchDialog_Click"/>
-                                <AppBarButton Icon="Add" Label="Create post" Click="OpenCreatePostDialog"/>
+                                <AppBarButton Icon="Refresh" Label="Refresh" x:Uid="Refresh" Click="Refresh"/>
+                                <AppBarButton Icon="Find" Label="Search" x:Uid="OpenSearchDialog" Click="OpenSearchDialog_Click"/>
+                                <AppBarButton Icon="Add" Label="Create post" x:Uid="OpenCreatePostDialog" Click="OpenCreatePostDialog"/>
                             </CommandBar>
                             <CommandBar Background='{ThemeResource SystemControlAcrylicWindowBrush}' x:Name="SignInBar" OverflowButtonVisibility="Collapsed" DefaultLabelPosition="Right">
-                                <AppBarButton Icon="AddFriend" Label="Sign in">
+                                <AppBarButton Icon="AddFriend" Label="Sign in" x:Uid="SignInABB">
                                     <AppBarButton.Flyout>
                                         <Flyout>
                                             <StackPanel>
-                                                <Button x:Name="SignIn" Click="SignIn_Click">Sign in</Button>
+                                                <Button x:Name="SignIn" x:Uid="SignIn" Click="SignIn_Click">Sign in</Button>
                                             </StackPanel>
                                         </Flyout>
                                     </AppBarButton.Flyout>
                                 </AppBarButton>
                             </CommandBar>
-                            <AppBarButton Icon="Setting" Label="Settings" x:Name="SB" x:Load="False" Click="SettingOpenButton_Click"/>
+                            <AppBarButton Icon="Setting" Label="Settings" x:Name="SB" x:Uid="SB" x:Load="False" Click="SettingOpenButton_Click"/>
                         </Grid>
                    
                     </Pivot.LeftHeader>
@@ -514,7 +514,7 @@
                                         <AppBarButton Icon="Back" Click="MyFancyPanel_BackdropClicked"></AppBarButton>
                                     </CommandBar>
                                 </Pivot.LeftHeader>
-                                <PivotItem Header="Settings">
+                                <PivotItem Header="Settings" x:Uid="SettingsPi">
                                     <StackPanel x:Name="ContentPanel">
                                         <TextBlock
                 x:Uid="Settings_Personalization"
@@ -560,22 +560,22 @@
                                             </StackPanel>
                                         </StackPanel>
                                         <StackPanel Orientation="Horizontal">
-                                            <Button Click="LivePin" Margin="10">Pin to startscreen</Button>
-                                            <Button Click="PinAppToTaskbar_Click" Margin="10">Pin to taskbar</Button>
+                                            <Button Click="LivePin" Margin="10" x:Uid="LivePin">Pin to startscreen</Button>
+                                            <Button Click="PinAppToTaskbar_Click" Margin="10" x:Uid="PinAppToTaskbar">Pin to taskbar</Button>
                                         </StackPanel>
                                         <StackPanel Orientation="Horizontal">
-                                            <Button Click="Rate_Click" Margin="10">Rate Appraisit</Button>
+                                            <Button Click="Rate_Click" Margin="10" x:Uid="Rate">Rate Appraisit</Button>
                                             <Button IsEnabled="False" x:Name="Feedbackbutton" FontFamily="Segoe MDL2 Assets" Content="&#xE939;" Margin="10" Click="FeedbackLink_Click">
                                             </Button>
                                         </StackPanel>
                                     </StackPanel>
                                 </PivotItem>
-                                <PivotItem Header="What's new">
+                                <PivotItem x:Uid="WhatsNewPI" Header="What's new">
                                     <StackPanel Orientation="Vertical">
-                                        <Button x:Name="Whatsnew" Click="Whatsnew_Click" Margin="10" VerticalAlignment="Center">What's new</Button>
+                                        <Button x:Name="Whatsnew" x:Uid="Whatsnew" Click="Whatsnew_Click" Margin="10" VerticalAlignment="Center">What's new</Button>
                                     </StackPanel>
                                 </PivotItem>
-                                <PivotItem Header="About">
+                                <PivotItem x:Uid="AboutPI" Header="About">
                                     <StackPanel>
                                         <TextBlock
                     x:Uid="Settings_About"
@@ -586,7 +586,7 @@
                     Text="{x:Bind VersionDescription, Mode=OneWay}"
                     Style="{ThemeResource BodyTextBlockStyle}" />
                                             <!--x:Uid="Settings_AboutDescription"-->
-                                            <HyperlinkButton
+                                            <HyperlinkButton x:Uid="PrivacyHB"
                     Content="Privacy Statement"
                     Margin="{StaticResource XSmallTopMargin}"
                     NavigateUri="https://www.websitepolicies.com/policies/view/ti1U34qB"/>
@@ -658,6 +658,7 @@
        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                  x:Name="CreatePostDialog"
+                x:Uid="CreatePostDialog"
                 CloseButtonText="Cancel"
                 PrimaryButtonText="Post"
                 PrimaryButtonClick="CreatePostDialog_PrimaryButtonClick"
@@ -666,20 +667,20 @@
                 x:Load="False">
                 <ScrollViewer>
                     <StackPanel Orientation="Vertical" Margin="50" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                    <TextBox Header="Title:" PlaceholderText="Appraisit updated to version 3.0" x:Name="TitlePostText"/>
+                    <TextBox Header="Title:" PlaceholderText="Appraisit updated to version 3.0" x:Name="TitlePostText" x:Uid="TitlePostText" />
                     <Pivot Name="NewPostPivot">
-                        <PivotItem Header="Text">
+                        <PivotItem Header="Text" x:Uid="TextPi">
                             <StackPanel Orientation="Vertical" Margin="50" >
-                                <TextBox Header="Text:" PlaceholderText="Remember to put version number, links are optional" TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="True" x:Name="PostText"/>
+                                <TextBox Header="Text:" PlaceholderText="Remember to put version number, links are optional" TextWrapping="Wrap" AcceptsReturn="True" IsSpellCheckEnabled="True" x:Name="PostText" x:Uid="PostText" />
                             </StackPanel>
                         </PivotItem>
-                        <PivotItem Header="Link">
+                        <PivotItem Header="Link" x:Uid="LinkPi">
                             <StackPanel Orientation="Vertical" Margin="50">
-                                <TextBox Header="Link:" PlaceholderText="Must be a valid link" x:Name="NewPostLink"/>
+                                <TextBox Header="Link:" PlaceholderText="Must be a valid link" x:Name="NewPostLink" x:Uid="NewPostLink" />
                             </StackPanel>
                         </PivotItem>
                     </Pivot>
-                    <TextBlock Text="Flair:" Style="{ThemeResource BaseTextBlockStyle}"/>
+                    <TextBlock Text="Flair:" Style="{ThemeResource BaseTextBlockStyle}" x:Uid="FlairLabel" />
                         <RadioButton Content="Update" IsChecked="True" Checked="UniversalRadioButton_Checked"/>
                         <RadioButton Content="Price Drop" Checked="UniversalRadioButton_Checked"/>
                         <RadioButton Content="New Release" Checked="UniversalRadioButton_Checked"/>
@@ -692,13 +693,14 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
             x:Name="PostDialog"
+                x:Uid="PostDialog"
                 x:Load="False"
         CloseButtonText="Close"
                 CloseButtonClick="PostDialog_CloseButtonClick"
         DefaultButton="Primary" Background='{ThemeResource SystemControlChromeMediumAcrylicElementMediumBrush}'>
                 <ScrollViewer>
                     <StackPanel VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Margin="10">
-                        <HyperlinkButton Content="Link" x:Name="LinkPostLink" Visibility="Collapsed"/>
+                        <HyperlinkButton Content="Link" x:Name="LinkPostLink" x:Uid="LinkPostLink" Visibility="Collapsed"/>
                         <TextBlock x:Name="PostContentText"
             TextWrapping="Wrap" />
                         <TextBlock x:Name="FlairText" Margin="10" TextWrapping="Wrap"></TextBlock>
@@ -707,22 +709,22 @@
                         <TextBlock x:Name="CreatedText"
             TextWrapping="Wrap" Margin="10"/>
                         <CommandBar Background='{ThemeResource SystemControlChromeMediumAcrylicWindowMediumBrush}' Margin="20">
-                            <AppBarButton x:Name="LinkNavigator" Icon="Link" Label="Link" Background='{ThemeResource SystemControlChromeMediumAcrylicWindowMediumBrush}' Click="LinkNavigator_Click" IsEnabled="False"/>
+                            <AppBarButton x:Name="LinkNavigator" x:Uid="LinkNavigator" Icon="Link" Label="Link" Background='{ThemeResource SystemControlChromeMediumAcrylicWindowMediumBrush}' Click="LinkNavigator_Click" IsEnabled="False"/>
                             <AppBarSeparator/>
                             <AppBarButton x:Name="Upvotes" Icon="Like"  Label="{Binding PostUpvotes}" Background='{ThemeResource SystemControlChromeMediumAcrylicWindowMediumBrush}' Click="Upvotes_Click"></AppBarButton>
                             <AppBarButton x:Name="Downvotes" Icon="Dislike" Label="{Binding PostDownvotes}" Background='{ThemeResource SystemControlChromeMediumAcrylicWindowMediumBrush}' Click="Downvotes_Click"></AppBarButton>
                             <AppBarSeparator/>
-                            <AppBarButton x:Name="Openinweb" Icon="Globe" Label="Web" Background="{ThemeResource SystemControlChromeMediumAcrylicWindowMediumBrush}" Click="PostInWebClick"></AppBarButton>
+                            <AppBarButton x:Name="Openinweb" x:Uid="Openinweb" Icon="Globe" Label="Web" Background="{ThemeResource SystemControlChromeMediumAcrylicWindowMediumBrush}" Click="PostInWebClick"></AppBarButton>
                             <CommandBar.SecondaryCommands>
-                                <AppBarButton Label="Search appraisit" Icon="Find" Click="bARFlyoutItem_Click_1"/>
-                                <AppBarButton Label="Search on reddit" Icon="Find" Click="bARFlyoutItem_Click_2"/>
-                                <AppBarButton Label="Search on store" Icon="Find" Click="bARenuFlyoutItem_Click"/>
+                                <AppBarButton x:Uid="SearchAppraisitABB" Label="Search appraisit" Icon="Find" Click="bARFlyoutItem_Click_1"/>
+                                <AppBarButton x:Uid="SearchRedditABB" Label="Search on reddit" Icon="Find" Click="bARFlyoutItem_Click_2"/>
+                                <AppBarButton x:Uid="SearchStoreABB" Label="Search on store" Icon="Find" Click="bARenuFlyoutItem_Click"/>
                                 <AppBarSeparator/>
-                                <AppBarButton Label="Refresh comments" Icon="Refresh" Click="MenuFlyoutItem_Click_3"/>
+                                <AppBarButton x:Uid="RefreshCommentsABB" Label="Refresh comments" Icon="Refresh" Click="MenuFlyoutItem_Click_3"/>
                             </CommandBar.SecondaryCommands>
                         </CommandBar>
                         <StackPanel Orientation="Vertical" Margin="20">
-                            <AutoSuggestBox Header="Comment:" PlaceholderText="this is a comment"  x:Name="CommentTextMessage" QueryIcon="Comment" QuerySubmitted="CommentTextMessage_QuerySubmitted"></AutoSuggestBox>
+                            <AutoSuggestBox Header="Comment:" PlaceholderText="this is a comment"  x:Name="CommentTextMessage" x:Uid="CommentTextMessage" QueryIcon="Comment" QuerySubmitted="CommentTextMessage_QuerySubmitted"></AutoSuggestBox>
                         </StackPanel>
                         <!--<controls:AdaptiveGridView  Name="UniversalCommentGridViewControl" ItemHeight="200" IsItemClickEnabled="False" MaxHeight="600" DesiredWidth="500" ItemTemplate="{StaticResource CommentsTemplate}">
                     </controls:AdaptiveGridView>-->
@@ -733,47 +735,47 @@
                             
                         </muxcontrols:TeachingTip>
                         <Pivot>
-                            <PivotItem Header="Best">
+                            <PivotItem Header="Best" x:Uid="BestPi">
                                 <muxcontrols:TreeView Name="UniversalCommentTreeViewControl"  ItemTemplate="{StaticResource CommentsTemplate}" >
 
                                 </muxcontrols:TreeView>
                             </PivotItem>
-                            <PivotItem Header="Replies (experimental)">
+                            <PivotItem Header="Replies (experimental)" x:Uid="RepliesPi">
                                 <muxcontrols:TreeView Name="RepliesCommentTreeViewControl"  ItemTemplate="{StaticResource CommentsTemplate}" >
 
                                 </muxcontrols:TreeView>
                             </PivotItem>
-                            <PivotItem Header="New">
+                            <PivotItem Header="New" x:Uid="NewPi">
                                 <muxcontrols:TreeView Name="NewCommentTreeViewControl"  ItemTemplate="{StaticResource CommentsTemplate}" >
 
                                 </muxcontrols:TreeView>
                             </PivotItem>
-                            <PivotItem Header="Top">
+                            <PivotItem Header="Top" x:Uid="TopPi">
                                 <muxcontrols:TreeView Name="TopCommentTreeViewControl"  ItemTemplate="{StaticResource CommentsTemplate}" >
 
                                 </muxcontrols:TreeView>
                             </PivotItem>
-                            <PivotItem Header="Controversial">
+                            <PivotItem Header="Controversial" x:Uid="ControversialPi">
                                 <muxcontrols:TreeView Name="ControversialCommentTreeViewControl"  ItemTemplate="{StaticResource CommentsTemplate}" >
 
                                 </muxcontrols:TreeView>
                             </PivotItem>
-                            <PivotItem Header="Old">
+                            <PivotItem Header="Old" x:Uid="OldPi">
                                 <muxcontrols:TreeView Name="OldCommentTreeViewControl"  ItemTemplate="{StaticResource CommentsTemplate}" >
 
                                 </muxcontrols:TreeView>
                             </PivotItem>
-                            <PivotItem Header='Q and A'>
+                            <PivotItem Header='Q and A' x:Uid="QandAPi">
                                 <muxcontrols:TreeView Name="QACommentTreeViewControl"  ItemTemplate="{StaticResource CommentsTemplate}" >
 
                                 </muxcontrols:TreeView>
                             </PivotItem>
-                            <PivotItem Header='Live'>
+                            <PivotItem Header='Live' x:Uid="LivePi">
                                 <muxcontrols:TreeView Name="LiveCommentTreeViewControl"  ItemTemplate="{StaticResource CommentsTemplate}" >
 
                                 </muxcontrols:TreeView>
                             </PivotItem>
-                            <PivotItem Header='Random'>
+                            <PivotItem Header='Random' x:Uid="RandomPi">
                                 <muxcontrols:TreeView Name="RandomCommentTreeViewControl"  ItemTemplate="{StaticResource CommentsTemplate}" >
 
                                 </muxcontrols:TreeView>
@@ -786,6 +788,7 @@
             <muxcontrols:TeachingTip x:Name="SearchTip"
                                  Title="Search"
                                      x:Load="False"
+                                     x:Uid="SearchTip"
             PreferredPlacement="Top">
                 <muxcontrols:TeachingTip.IconSource>
                     <muxcontrols:SymbolIconSource Symbol="Find" />
@@ -794,11 +797,12 @@
                 <StackPanel HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="10">
                     <AutoSuggestBox PlaceholderText="Search posts:"
                                 x:Name='SearchBox'
+                                    x:Uid="SearchBox"
         TextChanged="SearchBox_TextChanged"
         QueryIcon="Find"
         QuerySubmitted="SearchBox_QuerySubmitted"/>
                     <Pivot>
-                        <PivotItem Header="Reddit">
+                        <PivotItem Header="Reddit" x:Uid="RedditPi">
                             <controls:AdaptiveGridView  Name="SearchGridViewControl"
     MaxHeight="600"
     ItemHeight="200"
@@ -808,13 +812,13 @@
     ItemClick="UniversalGridViewControl_ItemClick">
                             </controls:AdaptiveGridView>
                         </PivotItem>
-                        <PivotItem Header="Store">
-                            <Button Content="Search Microsoft Store" Click="SearchMSButton_Click" HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <PivotItem Header="Store" x:Uid="StorePi">
+                            <Button x:Uid="SearchMicrosoftStoreButton" Content="Search Microsoft Store" Click="SearchMSButton_Click" HorizontalAlignment="Center" VerticalAlignment="Center">
                                 
                             </Button>
                         </PivotItem>
-                        <PivotItem Header="Web">
-                            <Button Content="Search reddit on web" Click="RedditSearch_Click" HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <PivotItem Header="Web" x:Uid="WebPi">
+                            <Button x:Uid="SearchRedditWebButton" Content="Search reddit on web" Click="RedditSearch_Click" HorizontalAlignment="Center" VerticalAlignment="Center">
 
                             </Button>
                         </PivotItem>

--- a/Appraisit/Views/MainPage.xaml.cs
+++ b/Appraisit/Views/MainPage.xaml.cs
@@ -121,7 +121,7 @@ namespace Appraisit.Views
                     }
                     MobileSignInBar.Visibility = Visibility.Visible;
                     UniversalPageTip.IsOpen = true;
-                    UniversalPageTip.Title = "Sign in to access more features such as light mode, search, create post, commenting and settings.";
+                    UniversalPageTip.Title = "SignInTip".GetLocalized();
                 }
                 else
                 {
@@ -154,7 +154,7 @@ namespace Appraisit.Views
                 }
             }
 
-
+            TopOrder.ItemsSource = "TopOrderItems".GetLocalized().Split('|');
 
             /*ProgressRing.IsActive = true;
             var scopes = Constants.Constants.scopeList.Aggregate("", (acc, x) => acc + " " + x);
@@ -270,11 +270,11 @@ namespace Appraisit.Views
                     if (AnalyticsInfo.VersionInfo.DeviceFamily == "Windows.Mobile")
                     {
                         UniversalPostTip.IsOpen = true;
-                        UniversalPostTip.Title = "No internet connection";
+                        UniversalPostTip.Title = "NoInternetConnection".GetLocalized();
                     }
                     else
                     {
-                        UniversalPageNotification.Show("No internet connection");
+                        UniversalPageNotification.Show("NoInternetConnection".GetLocalized());
                     }                    
                 }
                
@@ -406,7 +406,7 @@ namespace Appraisit.Views
                         PostContentText.Visibility = Visibility.Visible;
                         LinkPostLink.Visibility = Visibility.Collapsed;
                         PostContentText.Text = S.SelfText;
-                        FlairText.Text = "Flair: " + S.Listing.LinkFlairText;
+                        FlairText.Text = string.Format("Flair".GetLocalized(), S.Listing.LinkFlairText);
                         LinkNavigator.IsEnabled = false;
                         ReferencePost = new OpenPosts()
                         {
@@ -831,7 +831,7 @@ namespace Appraisit.Views
                     Uri Link = new Uri(L.URL.ToString());
                     LinkPostLink.Visibility = Visibility.Visible;
                     PostContentText.Visibility = Visibility.Collapsed;
-                    FlairText.Text = "Flair: " + L.Listing.LinkFlairText;
+                    FlairText.Text = string.Format("Flair".GetLocalized(), L.Listing.LinkFlairText);
                     LinkPostLink.NavigateUri = Link;
                     ReferencePost = new OpenPosts()
                     {
@@ -1220,7 +1220,7 @@ namespace Appraisit.Views
             if ((string)localSettings.Values["refresh_token"] == BackuprefreshToken)
             {
                 UniversalPostTip.IsOpen = true;
-                UniversalPostTip.Title = "Cant upvote without sign in";
+                UniversalPostTip.Title = "CantUpvoteWithoutSignin".GetLocalized();
             }
             else
             {
@@ -1228,11 +1228,11 @@ namespace Appraisit.Views
                 if (AnalyticsInfo.VersionInfo.DeviceFamily == "Windows.Mobile")
                 {
                     UniversalPostTip.IsOpen = true;
-                    UniversalPostTip.Title = "Upvoted";
+                    UniversalPostTip.Title = "Upvoted".GetLocalized();
                 }
                 else
                 {
-                    UniversalPostNotification.Show("Upvoted", 3000);
+                    UniversalPostNotification.Show("Upvoted".GetLocalized(), 3000);
                 }
                 await upvote.UpvoteAsync();
             }        
@@ -1243,7 +1243,7 @@ namespace Appraisit.Views
             if ((string)localSettings.Values["refresh_token"] == BackuprefreshToken)
             {
                 UniversalPostTip.IsOpen = true;
-                UniversalPostTip.Title = "Cant downvote without sign in";
+                UniversalPostTip.Title = "CantDownvoteWithoutSignin".GetLocalized();
             }
             else
             {
@@ -1251,11 +1251,11 @@ namespace Appraisit.Views
                 if (AnalyticsInfo.VersionInfo.DeviceFamily == "Windows.Mobile")
                 {
                     UniversalPostTip.IsOpen = true;
-                    UniversalPostTip.Title = "Downvoted";
+                    UniversalPostTip.Title = "Downvoted".GetLocalized();
                 }
                 else
                 {
-                    UniversalPostNotification.Show("Downvoted", 3000);
+                    UniversalPostNotification.Show("Downvoted".GetLocalized(), 3000);
                 }
                 await downvote.UpvoteAsync();
             }
@@ -1339,8 +1339,8 @@ namespace Appraisit.Views
                                         {
                                             TitleText = post.Title,
                                             PostSelf = post,
-                                            PostAuthor = "by: " + post.Author,
-                                            PostDate = "Created: " + post.Created,
+                                            PostAuthor = string.Format("PostBy".GetLocalized(), post.Author),
+                                            PostDate = string.Format("PostCreated", post.Created),
                                             PostUpvotes = post.UpVotes.ToString(),
                                             PostDownvotes = post.DownVotes.ToString(),
                                             PostCommentCount = post.Comments.GetComments("new").Count.ToString()
@@ -1489,7 +1489,7 @@ namespace Appraisit.Views
 
                     if (isPinned)
                     {
-                        await new MessageDialog("If not you can manually pin the app to the taskbar", "You already have the app pinned in your taskbar").ShowAsync();
+                        await new MessageDialog("AlreadyPinnedDesc".GetLocalized(), "AlreadyPinnedTitle".GetLocalized()).ShowAsync();
                     }
                     else
                     {
@@ -1499,7 +1499,7 @@ namespace Appraisit.Views
 
                 else
                 {
-                    await new MessageDialog("Update your device to the Fall creators update or higher to pin this app", "Update your device").ShowAsync();
+                    await new MessageDialog("UpdateToPin".GetLocalized(), "UpdateDevice".GetLocalized()).ShowAsync();
                 }
             }
 
@@ -1511,24 +1511,24 @@ namespace Appraisit.Views
                 switch (t)
                 {
                     case "Windows.Desktop":
-                        await new MessageDialog("It seems you are using a computer. Group policy disabled pinning of app in taskbar", "Taskbar pin failed").ShowAsync();
+                        await new MessageDialog("GPODisabledPin".GetLocalized(), "TaskbarPinFailed".GetLocalized()).ShowAsync();
                         break;
                     case "Windows.Mobile":
-                        await new MessageDialog("It seems you are using a Windows 10 on ARM device or mobile device. Group policy disabled pinning of the app", "Taskbar pin failed").ShowAsync();
+                        await new MessageDialog("WoADisabledPin".GetLocalized(), "TaskbarPinFailed".GetLocalized()).ShowAsync();
                         break;
                     case "Windows.IoT":
-                        await new MessageDialog("It seems you are using a IoT device which doesn't support taskbar pin API", "Taskbar pin failed").ShowAsync();
+                        await new MessageDialog("IoTDisabledPin".GetLocalized(), "TaskbarPinFailed".GetLocalized()).ShowAsync();
                         break;
                     case "Windows.Team":
                         break;
                     case "Windows.Holographic":
-                        await new MessageDialog("It seems you are using hololens. Hololens doesn't have a taskbar", "Taskbar pin failed").ShowAsync();
+                        await new MessageDialog("HololensDisabledPin".GetLocalized(), "TaskbarPinFailed".GetLocalized()).ShowAsync();
                         break;
                     case "Windows.Xbox":
-                        await new MessageDialog("It seems you are using a xbox. Xbox doesn't have a taskbar", "Taskbar pin failed").ShowAsync();
+                        await new MessageDialog("XboxDisabledPin".GetLocalized(), "TaskbarPinFailed".GetLocalized()).ShowAsync();
                         break;
                     default:
-                        await new MessageDialog("It seems you are using a " + t + " device. This device does not support taskbar API or Group policy disabled pinning of the app", "Taskbar pin failed").ShowAsync();
+                        await new MessageDialog(string.Format("OtherDisabledPin".GetLocalized(), t), "TaskbarPinFailed".GetLocalized()).ShowAsync();
                         break;
                 }
             }
@@ -1549,7 +1549,7 @@ namespace Appraisit.Views
                     bool isPinned = await StartScreenManager.GetDefault().ContainsAppListEntryAsync(entry);
                     if (isPinned)
                     {
-                        await new MessageDialog("If not you can manually put the live tile on to the StartScreen", "You already have the live tile in your StartScreen").ShowAsync();
+                        await new MessageDialog("AlreadyTileDesc".GetLocalized(), "AlreadyTile".GetLocalized()).ShowAsync();
                     }
                     else
                     {
@@ -1558,7 +1558,7 @@ namespace Appraisit.Views
                 }
                 else
                 {
-                    await new MessageDialog("You need to update your device to enable automatic pinning", "Update your device").ShowAsync();
+                    await new MessageDialog("UpdateToTile".GetLocalized(), "UpdateDevice".GetLocalized()).ShowAsync();
                 }
             }
             else
@@ -1567,18 +1567,18 @@ namespace Appraisit.Views
                 switch (t)
                 {
                     case "Windows.IoT":
-                        await new MessageDialog("It seems you are using a IoT device which doesn't support Primary tile API", "live tile failed").ShowAsync();
+                        await new MessageDialog("IoTTileFail".GetLocalized(), "LiveTileFailed".GetLocalized()).ShowAsync();
                         break;
                     case "Windows.Team":
                         break;
                     case "Windows.Holographic":
-                        await new MessageDialog("It seems you are using hololens. Hololens doesn't support live tile", "live tile failed").ShowAsync();
+                        await new MessageDialog("HololensTileFail".GetLocalized(), "LiveTileFailed".GetLocalized()).ShowAsync();
                         break;
                     case "Windows.Xbox":
-                        await new MessageDialog("It seems you are using a xbox. Xbox doesn't support live tile", "live tile failed").ShowAsync();
+                        await new MessageDialog("XboxTileFail".GetLocalized(), "LiveTileFailed".GetLocalized()).ShowAsync();
                         break;
                     default:
-                        await new MessageDialog("It seems you are using a " + t + " device. This device does not support Primary tile API", "live tile failed").ShowAsync();
+                        await new MessageDialog(string.Format("OtherTileFail".GetLocalized(), t), "LiveTileFailed".GetLocalized()).ShowAsync();
                         break;
                 }
             }
@@ -1768,11 +1768,11 @@ namespace Appraisit.Views
                 if (AnalyticsInfo.VersionInfo.DeviceFamily == "Windows.Mobile")
                 {
                     UniversalPostTip.IsOpen = true;
-                    UniversalPostTip.Title = "Post created (refresh to view)";
+                    UniversalPostTip.Title = "PostCreated".GetLocalized();
                 }
                 else
                 {
-                    UniversalPageNotification.Show("Post created (refresh to view)", 3000);
+                    UniversalPageNotification.Show("PostCreated".GetLocalized(), 3000);
                 }              
             });
         }
@@ -1791,27 +1791,27 @@ namespace Appraisit.Views
             {
                 var Topcollection = new IncrementalLoadingCollection<TopPostsClass, Posts>();
                 TopPostsClass TopGenerator = new TopPostsClass();
-                string newOrder = TopOrder.SelectedItem.ToString();
+                int newOrder = TopOrder.SelectedIndex;
                 switch (newOrder)
                 {
-                    case "all":
-                        TopGenerator.Order = newOrder;
+                    case 0:
+                        TopGenerator.Order = Helpers.TopOrder.All;
                         TopGridViewControl.ItemsSource = Topcollection;
                         break;
-                    case "year":
-                        TopGenerator.Order = newOrder;
+                    case 1:
+                        TopGenerator.Order = Helpers.TopOrder.Year;
                         TopGridViewControl.ItemsSource = Topcollection;
                         break;
-                    case "month":
-                        TopGenerator.Order = newOrder;
+                    case 2:
+                        TopGenerator.Order = Helpers.TopOrder.Month;
                         TopGridViewControl.ItemsSource = Topcollection;
                         break;
-                    case "week":
-                        TopGenerator.Order = newOrder;
+                    case 3:
+                        TopGenerator.Order = Helpers.TopOrder.Week;
                         TopGridViewControl.ItemsSource = Topcollection;
                         break;
-                    case "day":
-                        TopGenerator.Order = newOrder;
+                    case 4:
+                        TopGenerator.Order = Helpers.TopOrder.Day;
                         TopGridViewControl.ItemsSource = Topcollection;
                         break;
                 }
@@ -1848,10 +1848,10 @@ namespace Appraisit.Views
                 var reddit = new RedditAPI(appId, refreshToken, secret);
                 await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
                 {
-                    UserName.Text = "Username: " + reddit.Account.Me.Name;
-                    Cakeday.Text = "Created/Cake Day: " + reddit.Account.Me.Created.ToString();
-                    LinkKarma.Text = "Karma: " + reddit.Account.Me.LinkKarma;
-                    CommentKarma.Text = "Comment Karma: " + reddit.Account.Me.CommentKarma;
+                    UserName.Text = string.Format("MyUsername".GetLocalized(), reddit.Account.Me.Name);
+                    Cakeday.Text = string.Format("MyCreated".GetLocalized(), reddit.Account.Me.Created.ToString());
+                    LinkKarma.Text = string.Format("MyKarma".GetLocalized(), reddit.Account.Me.LinkKarma);
+                    CommentKarma.Text = string.Format("MyCommentKarma".GetLocalized(), reddit.Account.Me.CommentKarma);
                 });
             });
         }
@@ -2108,7 +2108,7 @@ namespace Appraisit.Views
             if ((string)localSettings.Values["refresh_token"] == BackuprefreshToken)
             {
                 UniversalPostTip.IsOpen = true;
-                UniversalPostTip.Title = "Cant reply without sign in";
+                UniversalPostTip.Title = "CantReplyWithoutSignin".GetLocalized();
             }
             else
             {
@@ -2122,7 +2122,7 @@ namespace Appraisit.Views
                         await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
                         {
                             UniversalPostTip.IsOpen = true;
-                            UniversalPostTip.Title = "Reply sent (viewing replies isnt supported, go to appraisit subreddit on web to view)";
+                            UniversalPostTip.Title = "ReplySent".GetLocalized();
                             var reddit = new RedditAPI(appId, refreshToken, secret);
                             var subreddit = reddit.Subreddit("Appraisit");
                             await dse.CommentSelf.ReplyAsync(sender.Text);
@@ -2143,7 +2143,7 @@ namespace Appraisit.Views
             if ((string)localSettings.Values["refresh_token"] == BackuprefreshToken)
             {
                 UniversalPostTip.IsOpen = true;
-                UniversalPostTip.Title = "Cant comment without sign in";
+                UniversalPostTip.Title = "CantCommentWithoutSign".GetLocalized();
             }
             else
             {
@@ -2152,7 +2152,7 @@ namespace Appraisit.Views
                 try
                 {
                     UniversalPostTip.IsOpen = true;
-                    UniversalPostTip.Title = "Comment sent (refresh to view)";
+                    UniversalPostTip.Title = "CommentSent".GetLocalized();
 
                     var reddit = new RedditAPI(appId, refreshToken, secret);
                     var subreddit = reddit.Subreddit("Appraisit");
@@ -2188,7 +2188,7 @@ namespace Appraisit.Views
             if ((string)localSettings.Values["refresh_token"] == BackuprefreshToken)
             {
                 UniversalPostTip.IsOpen = true;
-                UniversalPostTip.Title = "Cant upvote without sign in";
+                UniversalPostTip.Title = "CantUpvoteWithoutSignin".GetLocalized();
             }
             else
             {
@@ -2198,7 +2198,7 @@ namespace Appraisit.Views
                 if (AnalyticsInfo.VersionInfo.DeviceFamily == "Windows.Mobile")
                 {
                     UniversalPostTip.IsOpen = true;
-                    UniversalPostTip.Title = "Upvoted";
+                    UniversalPostTip.Title = "Upvoted".GetLocalized();
                     AppBarButton see = sender as AppBarButton;
                     var ll = see.Label;
                     ll = ll + 1;
@@ -2206,7 +2206,7 @@ namespace Appraisit.Views
                 }
                 else
                 {
-                    UniversalPostNotification.Show("Upvoted", 3000);
+                    UniversalPostNotification.Show("Upvoted".GetLocalized(), 3000);
                 }
                 await dse.CommentSelf.UpvoteAsync();
             }
@@ -2217,7 +2217,7 @@ namespace Appraisit.Views
             if ((string)localSettings.Values["refresh_token"] == BackuprefreshToken)
             {
                 UniversalPostTip.IsOpen = true;
-                UniversalPostTip.Title = "Cant upvote without sign in";
+                UniversalPostTip.Title = "CantDownvoteWithoutSignin".GetLocalized();
             }
             else
             {
@@ -2227,13 +2227,13 @@ namespace Appraisit.Views
                 if (AnalyticsInfo.VersionInfo.DeviceFamily == "Windows.Mobile")
                 {
                     UniversalPostTip.IsOpen = true;
-                    UniversalPostTip.Title = "Downvoted";
+                    UniversalPostTip.Title = "Downvoted".GetLocalized();
                     AppBarButton see = sender as AppBarButton;
                     see.Label = "-1";
                 }
                 else
                 {
-                    UniversalPostNotification.Show("Downvoted", 3000);
+                    UniversalPostNotification.Show("Downvoted".GetLocalized(), 3000);
                 }
                 await dse.CommentSelf.DownvoteAsync();
             }


### PR DESCRIPTION
So this PR is adding translation support by moving all hard-coded strings like "Sign in" to resources and using Resource helper (https://github.com/FireCubeStudios/Appraisit/blob/master/Appraisit/Helpers/ResourceExtensions.cs) to get localized version of this particular string, e.g.: `"SignIn".GetLocalized()` will be "Sign in" in en-US, but "Zaloguj się" in pl-PL.

Wherever string concatenation was needed, e.g. in case of "by: reddit user", `string.Format()` was used instead, so the localized resource has the `{0}` to put value in there.

The second step was to use `x:Uid` attribute to mark UI elements and resources with names like `TopPi.Header` - this resource sets "Header" property of element with `x:Uid` set to `TopPi`, which could be very different in different languages.

For tests I have added Polish translation. You can test it out by using this code in the constructor in App.xaml.cs:

```csharp
Windows.Globalization.ApplicationLanguages.PrimaryLanguageOverride = "pl";
```

Which sets temporarily default language for something different, to check out everything works.

To avoid hard-coding strings, I had to change out how TopOrder works, see 88359b2. 